### PR TITLE
タスク一覧の取得処理を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@
   - service (Domain Service) : DDD におけるドメインサービスを実装
 - usecase : Application Business Rules
   - 各ユースケースファイル : 機能別のユースケースを実装
+  - dto : 各ユースケースの InputData と OutputData を定義
 - adapter : Interface Adapters
-  - controller : Webインフラとの接続処理を実装
-  - repository : DBインフラとの接続処理 (Read以外) を実装
-  - query (Query Service) : DBインフラとの接続処理 (Readのみ) を実装
+  - controller : usecase と graph の中間処理を実装
+  - repository : usecase と dao の中間処理を実装
 - infrastructure : Frameworks & Drivers
-  - dao (Data Access Object) : MySQL とのやりとりを実装
-  - graph (GraphQL Server by gqlgen) : GraphQL サーバーとのやりとりを実装
+  - graph (GraphQL Server by gqlgen) : Webインフラとの接続処理を実装
+  - dao (Data Access Object) : DBインフラとの接続処理を実装
 
-基本的に依存方向は 同じレイヤー内 または 下位レイヤー -> 上位レイヤーとなるように実装をする。<br>
-※ 現在 Repository が上位レイヤーのDaoに依存しているため、今後の検討がさらに必要
+基本的に依存方向は 同じレイヤー内 または 下位レイヤー -> 上位レイヤーとなるように実装をする。

--- a/adapter/controller/task.go
+++ b/adapter/controller/task.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/adapter/repository"
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase/dto"
 )
 
 type taskViewModel struct {
@@ -28,29 +29,29 @@ func (v taskViewModel) UserID() string {
 type TaskController struct{}
 
 func (c TaskController) CreateTask(title string, content string, userID string) (*taskViewModel, error) {
-	input := usecase.NewCreateTaskInputData(title, content, userID)
+	input := dto.NewCreateTaskInputData(title, content, userID)
 	taskRepository := repository.NewTaskRepository()
 	interactor := usecase.NewCreateTaskInteractor(input, taskRepository)
 	output, err := interactor.Handle()
 	viewModel := &taskViewModel{
-		id:      output.ID(),
-		title:   output.Title(),
-		content: output.Content(),
-		userID:  output.UserID(),
+		id:      output.Task().ID(),
+		title:   output.Task().Title(),
+		content: output.Task().Content(),
+		userID:  output.Task().UserID(),
 	}
 	return viewModel, err
 }
 
 func (c TaskController) FindTask(id string) (*taskViewModel, error) {
-	input := usecase.NewFindTaskInputData(id)
+	input := dto.NewFindTaskInputData(id)
 	taskRepository := repository.NewTaskRepository()
 	interactor := usecase.NewFindTaskInteractor(input, taskRepository)
 	output, err := interactor.Handle()
 	viewModel := &taskViewModel{
-		id:      output.ID(),
-		title:   output.Title(),
-		content: output.Content(),
-		userID:  output.UserID(),
+		id:      output.Task().ID(),
+		title:   output.Task().Title(),
+		content: output.Task().Content(),
+		userID:  output.Task().UserID(),
 	}
 	return viewModel, err
 }

--- a/adapter/controller/task.go
+++ b/adapter/controller/task.go
@@ -55,3 +55,20 @@ func (c TaskController) FindTask(id string) (*taskViewModel, error) {
 	}
 	return viewModel, err
 }
+
+func (c TaskController) FetchUserTasks(userID string) ([]taskViewModel, error) {
+	input := dto.NewFetchTasksInputData(userID)
+	taskRepository := repository.NewTaskRepository()
+	interactor := usecase.NewFetchTasksInteractor(input, taskRepository)
+	output, err := interactor.Handle()
+	viewModel := []taskViewModel{}
+	for _, task := range output.Tasks() {
+		viewModel = append(viewModel, taskViewModel{
+			id:      task.ID(),
+			title:   task.Title(),
+			content: task.Content(),
+			userID:  task.UserID(),
+		})
+	}
+	return viewModel, err
+}

--- a/adapter/repository/task.go
+++ b/adapter/repository/task.go
@@ -1,14 +1,10 @@
 package repository
 
 import (
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/entity"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/infrastructure/dao"
-	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase"
 )
-
-type ITaskDao interface {
-	Create(id string, title string, content string, userID string) error
-	FindById(id string) (usecase.ITaskRow, error)
-}
 
 type taskRepository struct{}
 
@@ -16,13 +12,52 @@ func NewTaskRepository() taskRepository {
 	return taskRepository{}
 }
 
-func (r taskRepository) Create(id string, title string, content string, userID string) error {
+func (r taskRepository) Create(task entity.Task) (*entity.Task, error) {
 	dao := dao.TaskDao{}
-	err := dao.Create(id, title, content, userID)
-	return err
+	err := dao.Create(
+		task.ID().Value(),
+		task.Title().Value(),
+		task.Content().Value(),
+		task.UserID().Value(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &task, nil
 }
 
-func (q taskRepository) FindById(id string) (usecase.ITaskRow, error) {
+func (q taskRepository) FindById(id vo.ID) (*entity.Task, error) {
 	dao := dao.TaskDao{}
-	return dao.FindById(id)
+	row, err := dao.FindById(id.Value())
+	if err != nil {
+		return nil, err
+	}
+	task := taskFactory(row)
+	return &task, nil
+}
+
+type ITaskRow interface {
+	ID() string
+	Title() string
+	Content() string
+	UserID() string
+}
+
+type ITaskDao interface {
+	Create(id string, title string, content string, userID string) error
+	FindById(id string) (ITaskRow, error)
+}
+
+func taskFactory(taskRow ITaskRow) entity.Task {
+	id, _ := vo.NewID(taskRow.ID())
+	title, _ := vo.NewTaskTitle(taskRow.ID())
+	content, _ := vo.NewTaskContent(taskRow.ID())
+	userID, _ := vo.NewID(taskRow.ID())
+	// TODO: voのエラー処理を実装
+	return *entity.NewTask(
+		*id,
+		*title,
+		*content,
+		*userID,
+	)
 }

--- a/infrastructure/dao/task.go
+++ b/infrastructure/dao/task.go
@@ -63,7 +63,7 @@ func (TaskDao) FetchTasksByUserID(userID string) ([]taskRow, error) {
 	defer rows.Close()
 	for rows.Next() {
 		task := taskRow{}
-		if err := rows.Scan(&task.id, &task.title, &task.content, &task.userID); err != nil {
+		if err := rows.Scan(&task.id, &task.title, &task.content, &task.userID, &task.createdAt, &task.updatedAt); err != nil {
 			panic(err)
 		}
 		tasks = append(tasks, task)

--- a/infrastructure/dao/task.go
+++ b/infrastructure/dao/task.go
@@ -30,7 +30,7 @@ type TaskDao struct {
 	handler *sqlHandler
 }
 
-func (TaskDao) Create(id string, title string, content string, userID string) error {
+func (TaskDao) CreateTask(id string, title string, content string, userID string) error {
 	handler := newSqlHandler()
 	defer handler.connect.Close()
 	const sql = "INSERT INTO tasks (id, title, content, user_id) VALUES (?, ?, ?, ?);"
@@ -38,14 +38,36 @@ func (TaskDao) Create(id string, title string, content string, userID string) er
 	return err
 }
 
-func (TaskDao) FindById(taskID string) (*taskRow, error) {
+func (TaskDao) FindTaskByID(id string) (*taskRow, error) {
 	handler := newSqlHandler()
 	defer handler.connect.Close()
 
 	task := &taskRow{}
 	const stmt = "SELECT * FROM tasks WHERE id=?;"
-	row := handler.connect.QueryRow(stmt, taskID)
+	row := handler.connect.QueryRow(stmt, id)
 	err := row.Scan(&task.id, &task.title, &task.content, &task.userID, &task.createdAt, &task.updatedAt)
 
 	return task, err
+}
+
+func (TaskDao) FetchTasksByUserID(userID string) ([]taskRow, error) {
+	handler := newSqlHandler()
+	defer handler.connect.Close()
+
+	tasks := []taskRow{}
+	const stmt = "SELECT * FROM tasks WHERE user_id=?;"
+	rows, err := handler.connect.Query(stmt, userID)
+	if err != nil {
+		return tasks, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		task := taskRow{}
+		if err := rows.Scan(&task.id, &task.title, &task.content, &task.userID); err != nil {
+			panic(err)
+		}
+		tasks = append(tasks, task)
+	}
+
+	return tasks, err
 }

--- a/infrastructure/graph/schema/task.graphql
+++ b/infrastructure/graph/schema/task.graphql
@@ -13,7 +13,7 @@ input CreateTask {
 
 extend type Query {
     task(id: ID!): Task!
-    tasks: [Task!]!
+    tasks(userID: ID!): [Task!]!
 }
 
 extend type Mutation {

--- a/infrastructure/graph/task.resolvers.go
+++ b/infrastructure/graph/task.resolvers.go
@@ -45,8 +45,24 @@ func (r *queryResolver) Task(ctx context.Context, id string) (*model.Task, error
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *queryResolver) Tasks(ctx context.Context) ([]*model.Task, error) {
-	return r.tasks, nil
+func (r *queryResolver) Tasks(ctx context.Context, userID string) ([]*model.Task, error) {
+	taskController := controller.TaskController{}
+	viewModel, err := taskController.FetchUserTasks(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	dataModel := []*model.Task{}
+	for _, task := range viewModel {
+		dataModel = append(dataModel, &model.Task{
+			ID:      task.ID(),
+			Title:   task.Title(),
+			Content: task.Content(),
+			UserID:  task.UserID(),
+		})
+	}
+
+	return dataModel, nil
 }
 
 // Mutation returns generated.MutationResolver implementation.

--- a/usecase/create_task.go
+++ b/usecase/create_task.go
@@ -3,66 +3,32 @@ package usecase
 import (
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/entity"
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase/dto"
 	"github.com/google/uuid"
 )
 
 type createTaskInteractor struct {
-	input          createTaskInputData
+	input          dto.CreateTaskInputData
 	taskRepository ITaskRepository
 }
 
-func NewCreateTaskInteractor(input createTaskInputData, taskRepository ITaskRepository) *createTaskInteractor {
+func NewCreateTaskInteractor(input dto.CreateTaskInputData, taskRepository ITaskRepository) *createTaskInteractor {
 	return &createTaskInteractor{input: input, taskRepository: taskRepository}
 }
 
-func (i createTaskInteractor) Handle() (*createTaskOutputData, error) {
+func (i createTaskInteractor) Handle() (*dto.CreateTaskOutputData, error) {
 	generatedID, _ := uuid.NewRandom()
 	id, _ := vo.NewID(generatedID.String())
-	title, _ := vo.NewTaskTitle(i.input.title)
-	content, _ := vo.NewTaskContent(i.input.content)
-	userID, _ := vo.NewID(i.input.userID)
+	title, _ := vo.NewTaskTitle(i.input.Title())
+	content, _ := vo.NewTaskContent(i.input.Content())
+	userID, _ := vo.NewID(i.input.UserID())
 	newTask := entity.NewTask(*id, *title, *content, *userID)
 
-	task, dberror := i.taskRepository.Create(*newTask)
+	task, dberror := i.taskRepository.CreateTask(*newTask)
 	if dberror != nil {
 		return nil, dberror
 	}
 
-	output := &createTaskOutputData{
-		id:      task.ID().Value(),
-		title:   task.Title().Value(),
-		content: task.Content().Value(),
-		userID:  task.UserID().Value(),
-	}
+	output := dto.NewCreateTaskOutputData(*task)
 	return output, nil
-}
-
-type createTaskInputData struct {
-	title   string
-	content string
-	userID  string
-}
-
-func NewCreateTaskInputData(title string, content string, userID string) createTaskInputData {
-	return createTaskInputData{title: title, content: content, userID: userID}
-}
-
-type createTaskOutputData struct {
-	id      string
-	title   string
-	content string
-	userID  string
-}
-
-func (o createTaskOutputData) ID() string {
-	return o.id
-}
-func (o createTaskOutputData) Title() string {
-	return o.title
-}
-func (o createTaskOutputData) Content() string {
-	return o.content
-}
-func (o createTaskOutputData) UserID() string {
-	return o.userID
 }

--- a/usecase/dto/task_input.go
+++ b/usecase/dto/task_input.go
@@ -1,0 +1,42 @@
+package dto
+
+type CreateTaskInputData struct {
+	title   string
+	content string
+	userID  string
+}
+
+func NewCreateTaskInputData(title string, content string, userID string) CreateTaskInputData {
+	return CreateTaskInputData{title: title, content: content, userID: userID}
+}
+func (i CreateTaskInputData) Title() string {
+	return i.title
+}
+func (i CreateTaskInputData) Content() string {
+	return i.content
+}
+func (i CreateTaskInputData) UserID() string {
+	return i.userID
+}
+
+type FetchTasksInputData struct {
+	userID string
+}
+
+func NewFetchTasksInputData(userID string) FetchTasksInputData {
+	return FetchTasksInputData{userID: userID}
+}
+func (i FetchTasksInputData) UserID() string {
+	return i.userID
+}
+
+type FindTaskInputData struct {
+	id string
+}
+
+func NewFindTaskInputData(id string) FindTaskInputData {
+	return FindTaskInputData{id: id}
+}
+func (i FindTaskInputData) ID() string {
+	return i.id
+}

--- a/usecase/dto/task_output.go
+++ b/usecase/dto/task_output.go
@@ -1,0 +1,72 @@
+package dto
+
+import "github.com/clock-en/go-todo-on-ddd-on-ddd/domain/entity"
+
+type CreateTaskOutputData struct {
+	task taskData
+}
+
+func NewCreateTaskOutputData(task entity.Task) *CreateTaskOutputData {
+	return &CreateTaskOutputData{
+		task: createtaskData(task),
+	}
+}
+func (o CreateTaskOutputData) Task() taskData {
+	return o.task
+}
+
+type FetchTasksOutputData struct {
+	tasks []taskData
+}
+
+func NewFetchTasksOutputData(tasks []entity.Task) *FetchTasksOutputData {
+	slice := []taskData{}
+	for _, task := range tasks {
+		slice = append(slice, createtaskData(task))
+	}
+	return &FetchTasksOutputData{tasks: slice}
+}
+func (o FetchTasksOutputData) Tasks() []taskData {
+	return o.tasks
+}
+
+type FindTaskOutputData struct {
+	task taskData
+}
+
+func NewFindTaskOutputData(task entity.Task) *FindTaskOutputData {
+	return &FindTaskOutputData{
+		task: createtaskData(task),
+	}
+}
+func (o FindTaskOutputData) Task() taskData {
+	return o.task
+}
+
+type taskData struct {
+	id      string
+	title   string
+	content string
+	userID  string
+}
+
+func (t taskData) ID() string {
+	return t.id
+}
+func (t taskData) Title() string {
+	return t.title
+}
+func (t taskData) Content() string {
+	return t.content
+}
+func (t taskData) UserID() string {
+	return t.userID
+}
+func createtaskData(task entity.Task) taskData {
+	return taskData{
+		task.ID().Value(),
+		task.Title().Value(),
+		task.Content().Value(),
+		task.UserID().Value(),
+	}
+}

--- a/usecase/fetch_tasks.go
+++ b/usecase/fetch_tasks.go
@@ -1,0 +1,27 @@
+package usecase
+
+import (
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase/dto"
+)
+
+type fetchTasksInteractor struct {
+	input          dto.FetchTasksInputData
+	taskRepository ITaskRepository
+}
+
+func NewFetchTasksInteractor(input dto.FetchTasksInputData, taskRepository ITaskRepository) *fetchTasksInteractor {
+	return &fetchTasksInteractor{input: input, taskRepository: taskRepository}
+}
+
+func (i fetchTasksInteractor) Handle() (*dto.FetchTasksOutputData, error) {
+	userID, _ := vo.NewID(i.input.UserID())
+
+	tasks, dberror := i.taskRepository.FetchTasksByUserID(*userID)
+	if dberror != nil {
+		return nil, dberror
+	}
+
+	output := dto.NewFetchTasksOutputData(tasks)
+	return output, nil
+}

--- a/usecase/find_task.go
+++ b/usecase/find_task.go
@@ -2,58 +2,26 @@ package usecase
 
 import (
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/usecase/dto"
 )
 
 type findTaskInteractor struct {
-	input          findTaskInputData
+	input          dto.FindTaskInputData
 	taskRepository ITaskRepository
 }
 
-func NewFindTaskInteractor(input findTaskInputData, taskRepository ITaskRepository) *findTaskInteractor {
+func NewFindTaskInteractor(input dto.FindTaskInputData, taskRepository ITaskRepository) *findTaskInteractor {
 	return &findTaskInteractor{input: input, taskRepository: taskRepository}
 }
 
-func (i findTaskInteractor) Handle() (*findTaskOutputData, error) {
-	id, _ := vo.NewID(i.input.id)
+func (i findTaskInteractor) Handle() (*dto.FindTaskOutputData, error) {
+	id, _ := vo.NewID(i.input.ID())
 
-	task, dberror := i.taskRepository.FindById(*id)
+	task, dberror := i.taskRepository.FindTaskByID(*id)
 	if dberror != nil {
 		return nil, dberror
 	}
 
-	output := &findTaskOutputData{
-		id:      task.ID().Value(),
-		title:   task.Title().Value(),
-		content: task.Content().Value(),
-		userID:  task.UserID().Value(),
-	}
+	output := dto.NewFindTaskOutputData(*task)
 	return output, nil
-}
-
-type findTaskInputData struct {
-	id string
-}
-
-func NewFindTaskInputData(id string) findTaskInputData {
-	return findTaskInputData{id: id}
-}
-
-type findTaskOutputData struct {
-	id      string
-	title   string
-	content string
-	userID  string
-}
-
-func (o findTaskOutputData) ID() string {
-	return o.id
-}
-func (o findTaskOutputData) Title() string {
-	return o.title
-}
-func (o findTaskOutputData) Content() string {
-	return o.content
-}
-func (o findTaskOutputData) UserID() string {
-	return o.userID
 }

--- a/usecase/find_task.go
+++ b/usecase/find_task.go
@@ -4,6 +4,32 @@ import (
 	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
 )
 
+type findTaskInteractor struct {
+	input          findTaskInputData
+	taskRepository ITaskRepository
+}
+
+func NewFindTaskInteractor(input findTaskInputData, taskRepository ITaskRepository) *findTaskInteractor {
+	return &findTaskInteractor{input: input, taskRepository: taskRepository}
+}
+
+func (i findTaskInteractor) Handle() (*findTaskOutputData, error) {
+	id, _ := vo.NewID(i.input.id)
+
+	task, dberror := i.taskRepository.FindById(*id)
+	if dberror != nil {
+		return nil, dberror
+	}
+
+	output := &findTaskOutputData{
+		id:      task.ID().Value(),
+		title:   task.Title().Value(),
+		content: task.Content().Value(),
+		userID:  task.UserID().Value(),
+	}
+	return output, nil
+}
+
 type findTaskInputData struct {
 	id string
 }
@@ -30,30 +56,4 @@ func (o findTaskOutputData) Content() string {
 }
 func (o findTaskOutputData) UserID() string {
 	return o.userID
-}
-
-type findTaskInteractor struct {
-	input          findTaskInputData
-	taskRepository ITaskRepository
-}
-
-func NewFindTaskInteractor(input findTaskInputData, taskRepository ITaskRepository) *findTaskInteractor {
-	return &findTaskInteractor{input: input, taskRepository: taskRepository}
-}
-
-func (i findTaskInteractor) Handle() (*findTaskOutputData, error) {
-	id, _ := vo.NewID(i.input.id)
-
-	task, dberror := i.taskRepository.FindById(id.Value())
-	if dberror != nil {
-		return nil, dberror
-	}
-
-	output := &findTaskOutputData{
-		id:      task.ID(),
-		title:   task.Title(),
-		content: task.Content(),
-		userID:  task.UserID(),
-	}
-	return output, nil
 }

--- a/usecase/interfaces.go
+++ b/usecase/interfaces.go
@@ -6,6 +6,7 @@ import (
 )
 
 type ITaskRepository interface {
-	Create(entity.Task) (*entity.Task, error)
-	FindById(id vo.ID) (*entity.Task, error)
+	CreateTask(entity.Task) (*entity.Task, error)
+	FindTaskByID(id vo.ID) (*entity.Task, error)
+	FetchTasksByUserID(userID vo.ID) ([]entity.Task, error)
 }

--- a/usecase/repository.go
+++ b/usecase/repository.go
@@ -1,13 +1,11 @@
 package usecase
 
-type ITaskRow interface {
-	ID() string
-	Title() string
-	Content() string
-	UserID() string
-}
+import (
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/entity"
+	"github.com/clock-en/go-todo-on-ddd-on-ddd/domain/vo"
+)
 
 type ITaskRepository interface {
-	Create(id string, title string, content string, userID string) error
-	FindById(id string) (ITaskRow, error)
+	Create(entity.Task) (*entity.Task, error)
+	FindById(id vo.ID) (*entity.Task, error)
 }


### PR DESCRIPTION
- タスク一覧の取得 `Query tasks` を実装
- repository がドメインオブジェクトを返却するように修正
- dtoディレクトリを作成して usecase のデータ定義を外部化